### PR TITLE
fixed issue as IE11 doesn't have svg parentElement

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -13,7 +13,7 @@ const closest = function(el, selector, rootNode) {
       }
       break;
     }
-    element = element.parentElement;
+    element = element.parentNode;
   }
   return element;
 };
@@ -32,7 +32,7 @@ const getScrollElement = function(el) {
       element = null;
       break;
     }
-    element = element.parentElement;
+    element = element.parentNode;
   } while (element);
   return element;
 };


### PR DESCRIPTION
Hello! Great job, it works fine! But I have an icon in SVG and IE11 cannot return its parent element