### PR TITLE
Fixing a logic flaw in closest

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,9 +6,9 @@ const closest = function(el, selector, rootNode) {
                           || element.mozMatchesSelector
                           || element.msMatchesSelector;
   while (element) {
-    const flagRoot = element === rootElement;
-    if (flagRoot || matchesSelector.call(element, selector)) {
-      if (flagRoot) {
+    const isRoot = element === rootElement || element.tagName === 'HTML';
+    if (isRoot || matchesSelector.call(element, selector)) {
+      if (isRoot) {
         element = null;
       }
       break;

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ const closest = function(el, selector, rootNode) {
                           || element.mozMatchesSelector
                           || element.msMatchesSelector;
   while (element) {
-    const isRoot = element === rootNode || element.tagName === 'HTML';
+    const isRoot = element === rootNode || element === document.body;
     if (isRoot || matchesSelector.call(element, selector)) {
       if (isRoot) {
         element = null;

--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,11 @@
 const closest = function(el, selector, rootNode) {
-  const rootElement = rootNode || document.body;
   let element = el;
   const matchesSelector = element.matches
                           || element.webkitMatchesSelector
                           || element.mozMatchesSelector
                           || element.msMatchesSelector;
   while (element) {
-    const isRoot = element === rootElement || element.tagName === 'HTML';
+    const isRoot = element === rootNode || element.tagName === 'HTML';
     if (isRoot || matchesSelector.call(element, selector)) {
       if (isRoot) {
         element = null;


### PR DESCRIPTION
This PR should fix the issue #20 

When the wrapped table/list contains [portal](https://reactjs.org/docs/portals.html) child components, it's very likely that those portals will be put outside the root DOM node of the list/table. However, click events in the portals will still bubble up to the root React node ([this one](https://github.com/raisezhang/react-drag-listview/blob/master/src/ReactDragListView.jsx#L234) for instance). In that case, the logic in `closest` would fail when it's reaching the parent of `html` node. 

The quick fix here is to add the equality check of `html` node to avoid it from keeping moving up.